### PR TITLE
Duplicate skill cards

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ exclude:
   - functions
   - "*.gemspec"
   - "*.gem"
+  - "**/SKILL.md"
 
 # SEO
 author: Awesome Econ AI Stuff Contributors

--- a/cursor_chat_recording.md
+++ b/cursor_chat_recording.md
@@ -80,3 +80,16 @@ Assistant actions:
 - Implemented base URL detection for proper file fetching in Jekyll environment
 - Made `site.baseurl` available to JavaScript via `window.siteBaseurl` variable
 - Both buttons use existing button styles (`.btn`, `.btn-secondary`) for consistent design
+
+---
+
+## 2026-01-26 (Fix Duplicate Skill Cards)
+
+User request:
+- Skills appear twice. The same skill is visible in two cards. This is probably due to the existence of an index.md file and a SKILL.md file for every skill. We added index.md because Jekyll seemed unable to use SKILL.md for creating a page in the website. Is there a way to avoid duplication of cards?
+
+Assistant actions:
+- Identified that Jekyll was processing both `index.md` and `SKILL.md` files as collection items, causing duplicate skill cards
+- Added `**/SKILL.md` to the exclude list in `_config.yml` to prevent Jekyll from processing SKILL.md files as collection items
+- Now only `index.md` files are processed as collection items, eliminating duplicates
+- SKILL.md files remain in the repository for download purposes but are not processed by Jekyll


### PR DESCRIPTION
Exclude `SKILL.md` files from Jekyll processing to prevent duplicate skill cards.

Jekyll was processing both `index.md` and `SKILL.md` as collection items, causing each skill to appear twice. By excluding `**/SKILL.md` in `_config.yml`, only `index.md` files are processed for page generation, eliminating duplicates while `SKILL.md` files remain available for download.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d26793a-b5c4-4818-b0cb-efd0bf840116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d26793a-b5c4-4818-b0cb-efd0bf840116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where duplicate skill cards were appearing in collections.
* **Documentation**
  * Added documentation describing the duplicate skill cards fix and its impact on the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->