### PR TITLE
Fix "Download SKILL.md" button failing

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -171,6 +171,9 @@ async function downloadSkillFile() {
         // Remove trailing slash and add SKILL.md
         skillPath = skillPath.replace(/\/$/, '') + '/SKILL.md';
         
+        // Fix path: Jekyll serves from /skills/ but repo uses _skills/
+        skillPath = skillPath.replace(/^\/skills\//, '_skills/');
+        
         // Fetch the SKILL.md file (with fallback to GitHub raw URL)
         const content = await fetchFileContent(skillPath);
         


### PR DESCRIPTION
This pull request addresses a bug where the "Download SKILL.md" button on individual skill pages was failing.

The issue was caused by a mismatch between the URL path used by Jekyll (`/skills/`) and the actual repository path (`_skills/`) when constructing the URL for downloading the `SKILL.md` file. Additionally, Jekyll excludes `SKILL.md` files from its build process, meaning the download must rely on the GitHub raw URL fallback.

The fix modifies the `downloadSkillFile()` function in `assets/js/download.js` to prepend `_skills/` to the extracted `skillPath`. This ensures that the fallback URL correctly points to the `SKILL.md` file in the repository's structure, allowing the download to succeed.

<a href="https://capy.ai/project/9d9a68df-47b8-4d7c-a48b-2a949a21ba82/task/01910f7c-9908-401d-9a43-f0cc3c1a490d"><img alt="Review with Capy" src="https://capy.ai/review-with-capy.svg"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file path handling in download operations to ensure files are correctly retrieved from the repository fallback system, improving download reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->