### PR TITLE
fix(docs): README links use _skills/ path (fixes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Skills work with multiple AI coding assistants:
 # Clone a skill to your tools directory
 # Example for Claude Code:
 mkdir -p ~/.claude/skills
-cp -r skills/analysis/r-econometrics ~/.claude/skills/
+cp -r _skills/analysis/r-econometrics ~/.claude/skills/
 ```
 
 ### 3. Use the Skill
@@ -61,40 +61,40 @@ Invoke skills via slash commands or natural language:
 Skills are organized by research workflow stage:
 
 ### 💡 Ideation
-- [research-ideation](skills/ideation/research-ideation/) - Generate research questions from economic phenomena
+- [research-ideation](_skills/ideation/research-ideation/) - Generate research questions from economic phenomena
 
 ### 📚 Literature Review
-- [lit-review-assistant](skills/literature/lit-review-assistant/) - Search, summarize, and synthesize papers
+- [lit-review-assistant](_skills/literature/lit-review-assistant/) - Search, summarize, and synthesize papers
 
 ### 📐 Theory & Modeling
-- [latex-econ-model](skills/theory/latex-econ-model/) - Write economic models in LaTeX
-- [general-equilibrium-model-builder](skills/theory/general-equilibrium-model-builder/) - Build and solve Walrasian GE models in Julia
-- [game-theory-solver](skills/theory/game-theory-solver/) - Solve and visualize game theory problems
+- [latex-econ-model](_skills/theory/latex-econ-model/) - Write economic models in LaTeX
+- [general-equilibrium-model-builder](_skills/theory/general-equilibrium-model-builder/) - Build and solve Walrasian GE models in Julia
+- [game-theory-solver](_skills/theory/game-theory-solver/) - Solve and visualize game theory problems
 
 ### 📊 Data Management
-- [stata-data-cleaning](skills/data/stata-data-cleaning/) - Clean and transform data in Stata
-- [api-data-fetcher](skills/data/api-data-fetcher/) - Fetch data from economic APIs (FRED, World Bank)
+- [stata-data-cleaning](_skills/data/stata-data-cleaning/) - Clean and transform data in Stata
+- [api-data-fetcher](_skills/data/api-data-fetcher/) - Fetch data from economic APIs (FRED, World Bank)
 
 ### 🔬 Econometric Analysis
-- [r-econometrics](skills/analysis/r-econometrics/) - Run IV, DiD, RDD in R
-- [python-panel-data](skills/analysis/python-panel-data/) - Panel data analysis with Python
-- [stata-regression](skills/analysis/stata-regression/) - Regression analysis in Stata
+- [r-econometrics](_skills/analysis/r-econometrics/) - Run IV, DiD, RDD in R
+- [python-panel-data](_skills/analysis/python-panel-data/) - Panel data analysis with Python
+- [stata-regression](_skills/analysis/stata-regression/) - Regression analysis in Stata
 
 ### 📝 Academic Writing
-- [academic-paper-writer](skills/writing/academic-paper-writer/) - Draft papers with proper structure
-- [latex-tables](skills/writing/latex-tables/) - Generate publication-ready LaTeX tables
-- [referee-response](skills/writing/referee-response/) - Draft referee report responses
+- [academic-paper-writer](_skills/writing/academic-paper-writer/) - Draft papers with proper structure
+- [latex-tables](_skills/writing/latex-tables/) - Generate publication-ready LaTeX tables
+- [referee-response](_skills/writing/referee-response/) - Draft referee report responses
 
 ### 🎯 Communication
-- [beamer-presentation](skills/communication/beamer-presentation/) - Create Beamer slides
-- [econ-visualization](skills/communication/econ-visualization/) - Publication-quality charts
-- [research-website](skills/communication/research-website/) - Build academic project websites
+- [beamer-presentation](_skills/communication/beamer-presentation/) - Create Beamer slides
+- [econ-visualization](_skills/communication/econ-visualization/) - Publication-quality charts
+- [research-website](_skills/communication/research-website/) - Build academic project websites
 
 ---
 
 ## Creating Skills
 
-See our [Skill Template](skills/SKILL_TEMPLATE.md) and [Contributing Guide](CONTRIBUTING.md).
+See our [Skill Template](_skills/SKILL_TEMPLATE.md) and [Contributing Guide](CONTRIBUTING.md).
 
 Basic structure:
 ```yaml

--- a/cursor_chat_recording.md
+++ b/cursor_chat_recording.md
@@ -105,3 +105,14 @@ Assistant actions:
 - Identified the root cause: `SKILLS_LIST` in `download.js` was referencing paths starting with `skills/...` but the actual folder in the repository is `_skills/...` (with underscore prefix)
 - Updated all 12 skill paths in `SKILLS_LIST` from `skills/` to `_skills/` to match the actual folder structure
 - This fix ensures the fetch requests target the correct file paths, allowing the SKILL.md files to be downloaded and added to the zip file
+
+---
+
+## 2026-03-22 (GitHub issue #24 — README broken links)
+
+User request:
+- Fix GitHub issue #24 about the README (broken internal links).
+
+Assistant actions:
+- Issue: catalog and template links used `skills/...` but the repository stores skills under `_skills/` (Jekyll collection), so GitHub resolved links to non-existent paths.
+- Updated README: all skill catalog links, `Skill Template` link, and the `cp` quick-start example now use `_skills/` paths so links resolve on github.com.

--- a/cursor_chat_recording.md
+++ b/cursor_chat_recording.md
@@ -116,3 +116,10 @@ User request:
 Assistant actions:
 - Issue: catalog and template links used `skills/...` but the repository stores skills under `_skills/` (Jekyll collection), so GitHub resolved links to non-existent paths.
 - Updated README: all skill catalog links, `Skill Template` link, and the `cp` quick-start example now use `_skills/` paths so links resolve on github.com.
+
+User request:
+- Open a PR for the README fix.
+
+Assistant actions:
+- Branch `fix/readme-skill-links-issue-24`, commit, push to `origin`, opened PR: https://github.com/meleantonio/awesome-econ-ai-stuff/pull/26
+


### PR DESCRIPTION
## Summary

Issue #24 reported broken internal links in the README because they pointed at `skills/` while the repository stores skills under `_skills/` (Jekyll collection).

## Changes

- Update all skill catalog links and the Skill Template link to `_skills/...`.
- Update the Quick Start `cp` example to copy from `_skills/analysis/r-econometrics`.
- Append session note to `cursor_chat_recording.md`.

Closes #24

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links and references across guides to ensure accurate navigation to skill directories, templates, and resources with current paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->