### PR TITLE
fix(docs): remove README links to missing _skills/ entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Skills are organized by research workflow stage:
 ### 📐 Theory & Modeling
 - [latex-econ-model](_skills/theory/latex-econ-model/) - Write economic models in LaTeX
 - [general-equilibrium-model-builder](_skills/theory/general-equilibrium-model-builder/) - Build and solve Walrasian GE models in Julia
-- [game-theory-solver](_skills/theory/game-theory-solver/) - Solve and visualize game theory problems
 
 ### 📊 Data Management
 - [stata-data-cleaning](_skills/data/stata-data-cleaning/) - Clean and transform data in Stata
@@ -83,12 +82,10 @@ Skills are organized by research workflow stage:
 ### 📝 Academic Writing
 - [academic-paper-writer](_skills/writing/academic-paper-writer/) - Draft papers with proper structure
 - [latex-tables](_skills/writing/latex-tables/) - Generate publication-ready LaTeX tables
-- [referee-response](_skills/writing/referee-response/) - Draft referee report responses
 
 ### 🎯 Communication
 - [beamer-presentation](_skills/communication/beamer-presentation/) - Create Beamer slides
 - [econ-visualization](_skills/communication/econ-visualization/) - Publication-quality charts
-- [research-website](_skills/communication/research-website/) - Build academic project websites
 
 ---
 

--- a/cursor_chat_recording.md
+++ b/cursor_chat_recording.md
@@ -134,4 +134,5 @@ User request:
 Assistant actions:
 - Confirmed no `_skills/theory/game-theory-solver`, `_skills/writing/referee-response`, or `_skills/communication/research-website` in the repo.
 - Removed the three bullets from README and clarified the earlier #24 session note in this file.
+- Opened PR: https://github.com/meleantonio/awesome-econ-ai-stuff/pull/27
 

--- a/cursor_chat_recording.md
+++ b/cursor_chat_recording.md
@@ -116,10 +116,22 @@ User request:
 Assistant actions:
 - Issue: catalog and template links used `skills/...` but the repository stores skills under `_skills/` (Jekyll collection), so GitHub resolved links to non-existent paths.
 - Updated README: all skill catalog links, `Skill Template` link, and the `cp` quick-start example now use `_skills/` paths so links resolve on github.com.
+- Follow-up: removed three catalog lines (`game-theory-solver`, `referee-response`, `research-website`) because those directories are not present under `_skills/`; keeping them would still 404 on GitHub.
 
 User request:
 - Open a PR for the README fix.
 
 Assistant actions:
 - Branch `fix/readme-skill-links-issue-24`, commit, push to `origin`, opened PR: https://github.com/meleantonio/awesome-econ-ai-stuff/pull/26
+
+---
+
+## 2026-03-22 (README: remove catalog entries for missing skills)
+
+User request:
+- Verify and fix: README linked to `game-theory-solver`, `referee-response`, and `research-website` under `_skills/` but those directories do not exist; remove those lines; open a PR.
+
+Assistant actions:
+- Confirmed no `_skills/theory/game-theory-solver`, `_skills/writing/referee-response`, or `_skills/communication/research-website` in the repo.
+- Removed the three bullets from README and clarified the earlier #24 session note in this file.
 


### PR DESCRIPTION
## Summary

The README catalog listed three skills whose folders are not in the repository: `game-theory-solver`, `referee-response`, and `research-website`. After the `skills/` → `_skills/` path fix (PR #26), those URLs would still 404 on GitHub.

## Changes

- Remove the three catalog lines from `README.md`.
- Update `cursor_chat_recording.md`: note the follow-up and log this change.

Made with [Cursor](https://cursor.com)