### PR TITLE
feat: Engineering Cursor skills and site integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           from pathlib import Path
           import re
 
-          skills_root = Path("skills")
+          skills_root = Path("_skills")
           if skills_root.exists():
               for skill_file in skills_root.rglob("SKILL.md"):
                   text = skill_file.read_text(encoding="utf-8")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Open a [Skill Proposal Issue](https://github.com/meleantonio/awesome-econ-ai-stu
 
 1. Fork this repository
 2. Create a new branch: `git checkout -b skill/your-skill-name`
-3. Add your skill in `skills/<workflow-stage>/your-skill-name/SKILL.md`
+3. Add your skill in `_skills/<workflow-stage>/your-skill-name/SKILL.md`
 4. Update `README.md` to include your skill in the catalog
 5. Submit a pull request
 
@@ -77,7 +77,7 @@ Every skill must include a `SKILL.md` file with YAML frontmatter:
 ---
 name: your-skill-name
 description: A one-line description (shown during skill discovery)
-workflow_stage: analysis  # One of: ideation, literature, theory, data, analysis, writing, communication
+workflow_stage: analysis  # One of: ideation, literature, theory, data, analysis, writing, communication, engineering
 compatibility:
   - claude-code
   - cursor

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Skills are organized by research workflow stage:
 - [beamer-presentation](_skills/communication/beamer-presentation/) - Create Beamer slides
 - [econ-visualization](_skills/communication/econ-visualization/) - Publication-quality charts
 
+### ⚙️ Engineering
+- [sdd](_skills/engineering/sdd/) - Spec-Driven Development lifecycle (requirements, design, tasks)
+- [techdebt](_skills/engineering/techdebt/) - Find and fix technical debt
+- [commit-push-pr](_skills/engineering/commit-push-pr/) - Commit, push, and open a pull request
+- [code-simplifier](_skills/engineering/code-simplifier/) - Simplify and clean up code after changes
+
 ---
 
 ## Creating Skills

--- a/_layouts/skill.html
+++ b/_layouts/skill.html
@@ -45,8 +45,11 @@ layout: null
         <section>
             <div class="container">
                 <div class="skill-content">
-                    <div style="margin-bottom: 2rem; display: flex; justify-content: flex-end;">
+                    <div style="margin-bottom: 2rem; display: flex; justify-content: flex-end; gap: 0.5rem; flex-wrap: wrap;">
                         <button id="download-skill-btn" class="btn btn-secondary">📥 Download SKILL.md</button>
+                        {% if page.url contains '/engineering/sdd' %}
+                        <button id="download-skill-bundle-btn" type="button" class="btn btn-secondary">📦 Download full skill (zip)</button>
+                        {% endif %}
                     </div>
                     {{ content }}
                 </div>

--- a/_skills/engineering/code-simplifier/SKILL.md
+++ b/_skills/engineering/code-simplifier/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: code-simplifier
+description: Simplify and clean up code after changes are complete. Reduces complexity, improves readability, and ensures consistency.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+disable-model-invocation: true
+tags:
+  - refactoring
+  - python
+  - readability
+---
+
+# Code Simplifier
+
+Clean up and simplify code after making changes.
+
+## When to Use
+
+Run this skill after completing a feature or fix to ensure the code is clean, readable, and maintainable.
+
+## Simplification Goals
+
+### Reduce Complexity
+- Break long functions into smaller, focused ones
+- Reduce nesting depth (max 3 levels)
+- Simplify complex conditionals
+- Extract magic numbers to named constants
+
+### Improve Readability
+- Use descriptive variable and function names
+- Add clarifying comments for non-obvious logic
+- Ensure consistent formatting
+- Remove unnecessary comments
+
+### Apply Pythonic Patterns
+- Use list/dict/set comprehensions where appropriate
+- Use `with` statements for resource management
+- Use `enumerate()` instead of manual indexing
+- Use `zip()` for parallel iteration
+- Use f-strings for formatting
+- Use `pathlib` for file paths
+
+### Clean Up
+- Remove unused imports
+- Remove unused variables
+- Remove commented-out code
+- Remove redundant code paths
+- Consolidate duplicate logic
+
+## Workflow
+
+1. **Identify Changed Files**
+   - Focus on files modified in the current session
+   - Or specify files/directories as arguments
+
+2. **Analyze Each File**
+   - Check for simplification opportunities
+   - Prioritize high-impact improvements
+
+3. **Apply Simplifications**
+   - Make incremental changes
+   - Preserve original behavior
+   - Run tests after each change
+
+4. **Format and Lint**
+   - Run `ruff format .`
+   - Run `ruff check --fix .`
+
+5. **Verify**
+   - Run tests: `pytest`
+   - Ensure behavior unchanged
+
+## Arguments
+
+Optionally specify files or directories to simplify.
+
+Usage:
+- `/code-simplifier` - Simplify recently changed files
+- `/code-simplifier src/module.py` - Simplify specific file
+- `/code-simplifier src/` - Simplify entire directory
+
+## Example Transformations
+
+Before:
+```python
+result = []
+for i in range(len(items)):
+    if items[i].is_valid == True:
+        result.append(items[i].value)
+```
+
+After:
+```python
+result = [item.value for item in items if item.is_valid]
+```
+
+Before:
+```python
+if x != None:
+    if y != None:
+        if z != None:
+            process(x, y, z)
+```
+
+After:
+```python
+if all(v is not None for v in (x, y, z)):
+    process(x, y, z)
+```

--- a/_skills/engineering/code-simplifier/index.md
+++ b/_skills/engineering/code-simplifier/index.md
@@ -1,0 +1,115 @@
+---
+name: code-simplifier
+description: Simplify and clean up code after changes are complete. Reduces complexity, improves readability, and ensures consistency.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+disable-model-invocation: true
+tags:
+  - refactoring
+  - python
+  - readability
+---
+
+# Code Simplifier
+
+Clean up and simplify code after making changes.
+
+## When to Use
+
+Run this skill after completing a feature or fix to ensure the code is clean, readable, and maintainable.
+
+## Simplification Goals
+
+### Reduce Complexity
+- Break long functions into smaller, focused ones
+- Reduce nesting depth (max 3 levels)
+- Simplify complex conditionals
+- Extract magic numbers to named constants
+
+### Improve Readability
+- Use descriptive variable and function names
+- Add clarifying comments for non-obvious logic
+- Ensure consistent formatting
+- Remove unnecessary comments
+
+### Apply Pythonic Patterns
+- Use list/dict/set comprehensions where appropriate
+- Use `with` statements for resource management
+- Use `enumerate()` instead of manual indexing
+- Use `zip()` for parallel iteration
+- Use f-strings for formatting
+- Use `pathlib` for file paths
+
+### Clean Up
+- Remove unused imports
+- Remove unused variables
+- Remove commented-out code
+- Remove redundant code paths
+- Consolidate duplicate logic
+
+## Workflow
+
+1. **Identify Changed Files**
+   - Focus on files modified in the current session
+   - Or specify files/directories as arguments
+
+2. **Analyze Each File**
+   - Check for simplification opportunities
+   - Prioritize high-impact improvements
+
+3. **Apply Simplifications**
+   - Make incremental changes
+   - Preserve original behavior
+   - Run tests after each change
+
+4. **Format and Lint**
+   - Run `ruff format .`
+   - Run `ruff check --fix .`
+
+5. **Verify**
+   - Run tests: `pytest`
+   - Ensure behavior unchanged
+
+## Arguments
+
+Optionally specify files or directories to simplify.
+
+Usage:
+- `/code-simplifier` - Simplify recently changed files
+- `/code-simplifier src/module.py` - Simplify specific file
+- `/code-simplifier src/` - Simplify entire directory
+
+## Example Transformations
+
+Before:
+```python
+result = []
+for i in range(len(items)):
+    if items[i].is_valid == True:
+        result.append(items[i].value)
+```
+
+After:
+```python
+result = [item.value for item in items if item.is_valid]
+```
+
+Before:
+```python
+if x != None:
+    if y != None:
+        if z != None:
+            process(x, y, z)
+```
+
+After:
+```python
+if all(v is not None for v in (x, y, z)):
+    process(x, y, z)
+```

--- a/_skills/engineering/commit-push-pr/SKILL.md
+++ b/_skills/engineering/commit-push-pr/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: commit-push-pr
+description: Commit changes, push to remote, and create a pull request. Use for completing features or fixes ready for review.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+disable-model-invocation: true
+tags:
+  - git
+  - github
+  - pull-request
+---
+
+# Commit, Push, and Create PR
+
+Automate the git workflow for completing a feature or fix.
+
+## Pre-computed Context
+
+Before proceeding, gather this information:
+- Current branch: `!git branch --show-current`
+- Git status: `!git status --short`
+- Recent commits on this branch: `!git log --oneline -5`
+- Diff summary: `!git diff --stat`
+
+## Workflow
+
+1. **Review Changes**
+   - Check `git status` for all modified/added files
+   - Review the diff to understand what's being committed
+   - Ensure no sensitive files are staged (.env, credentials, etc.)
+
+2. **Run Pre-commit Checks**
+   - Format code: `ruff format .` (if Python files changed)
+   - Lint code: `ruff check .` (if Python files changed)
+   - Run tests: `pytest` (if tests exist)
+
+3. **Stage and Commit**
+   - Stage relevant files: `git add <files>`
+   - Create a commit with Conventional Commits format:
+     - `feat:` for new features
+     - `fix:` for bug fixes
+     - `docs:` for documentation
+     - `refactor:` for refactoring
+     - `test:` for tests
+     - `chore:` for maintenance
+   - Write a clear, concise commit message focusing on "why"
+
+4. **Push to Remote**
+   - Push the branch: `git push -u origin HEAD`
+   - If branch doesn't exist on remote, create it
+
+5. **Create Pull Request**
+   - Use GitHub CLI: `gh pr create`
+   - Include:
+     - Clear title summarizing the change
+     - Description with summary and context
+     - Reference any related issues
+   - Add appropriate labels if applicable
+
+## Arguments
+
+Pass a commit message or leave empty for auto-generated message based on changes.
+
+Usage: `/commit-push-pr [optional commit message]`
+
+Example: `/commit-push-pr feat: add user authentication`
+
+## Output
+
+Return the PR URL when complete.

--- a/_skills/engineering/commit-push-pr/index.md
+++ b/_skills/engineering/commit-push-pr/index.md
@@ -1,0 +1,76 @@
+---
+name: commit-push-pr
+description: Commit changes, push to remote, and create a pull request. Use for completing features or fixes ready for review.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+disable-model-invocation: true
+tags:
+  - git
+  - github
+  - pull-request
+---
+
+# Commit, Push, and Create PR
+
+Automate the git workflow for completing a feature or fix.
+
+## Pre-computed Context
+
+Before proceeding, gather this information:
+- Current branch: `!git branch --show-current`
+- Git status: `!git status --short`
+- Recent commits on this branch: `!git log --oneline -5`
+- Diff summary: `!git diff --stat`
+
+## Workflow
+
+1. **Review Changes**
+   - Check `git status` for all modified/added files
+   - Review the diff to understand what's being committed
+   - Ensure no sensitive files are staged (.env, credentials, etc.)
+
+2. **Run Pre-commit Checks**
+   - Format code: `ruff format .` (if Python files changed)
+   - Lint code: `ruff check .` (if Python files changed)
+   - Run tests: `pytest` (if tests exist)
+
+3. **Stage and Commit**
+   - Stage relevant files: `git add <files>`
+   - Create a commit with Conventional Commits format:
+     - `feat:` for new features
+     - `fix:` for bug fixes
+     - `docs:` for documentation
+     - `refactor:` for refactoring
+     - `test:` for tests
+     - `chore:` for maintenance
+   - Write a clear, concise commit message focusing on "why"
+
+4. **Push to Remote**
+   - Push the branch: `git push -u origin HEAD`
+   - If branch doesn't exist on remote, create it
+
+5. **Create Pull Request**
+   - Use GitHub CLI: `gh pr create`
+   - Include:
+     - Clear title summarizing the change
+     - Description with summary and context
+     - Reference any related issues
+   - Add appropriate labels if applicable
+
+## Arguments
+
+Pass a commit message or leave empty for auto-generated message based on changes.
+
+Usage: `/commit-push-pr [optional commit message]`
+
+Example: `/commit-push-pr feat: add user authentication`
+
+## Output
+
+Return the PR URL when complete.

--- a/_skills/engineering/sdd/SKILL.md
+++ b/_skills/engineering/sdd/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: sdd
+description: >
+  Implements the Spec-Driven Development lifecycle (Intent, Requirements, Design, Tasks, Build)
+  for structured feature development. Use when the user wants to scaffold a new feature spec,
+  generate EARS requirements, create a technical design, break work into tasks, or check spec status.
+  Trigger on keywords: sdd, spec-driven, ears requirements, feature spec.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+tags:
+  - spec-driven-development
+  - requirements
+  - design
+  - documentation
+---
+
+# Spec-Driven Development (SDD)
+
+## Core Philosophy
+
+1. **Clarity before Code:** Never generate code until requirements and design are approved.
+2. **Iterative Refinement:** Loop through Req → Design → Tasks until solid.
+3. **Code via Docs:** The truth is in the markdown files, not the chat.
+
+## Commands
+
+Execute in the **project root** (where `spec/` and `steering/` live).
+
+### `init`
+
+Scaffold the SDD folder structure and template files.
+
+1. If `spec/` already exists, skip or ask before overwriting.
+2. Create `spec/` and `steering/`.
+3. Create `spec/intent.md` (blank or minimal placeholder).
+4. Copy templates from this skill’s `templates/` directory (in the same folder as `SKILL.md`, or from your install path under `~/.cursor/skills/sdd/` after copying the skill there) into the project:
+   - `templates/spec/requirements.md` → `spec/requirements.md`
+   - `templates/spec/design.md` → `spec/design.md`
+   - `templates/spec/tasks.md` → `spec/tasks.md`
+   - `templates/steering/coding-standards.md` → `steering/coding-standards.md`
+
+### `reqs`
+
+Generate EARS requirements from intent.
+
+1. Read `spec/intent.md` and `steering/*.md`.
+2. Convert the intent into EARS requirements (see EARS Quick Reference below). Add a Properties (invariants) section.
+3. Write to `spec/requirements.md`.
+4. Ask for user approval before proceeding.
+
+### `design`
+
+Generate technical design from requirements.
+
+1. Read `spec/requirements.md` and `steering/*.md`.
+2. Create a technical design: architecture, data models, component interfaces, error handling, security. Apply the Design Checklist below.
+3. Write to `spec/design.md`.
+4. Ask for user approval before proceeding.
+
+### `tasks`
+
+Generate implementation tasks from design.
+
+1. Read `spec/design.md` and `spec/requirements.md`.
+2. Create a sequential task list: max two levels (Task > Subtask). Link each task to requirement IDs (e.g. `REQ-001`). Follow Task Rules below.
+3. Write to `spec/tasks.md`.
+4. Ask for user approval before proceeding.
+
+### `status`
+
+Report current state of the spec.
+
+1. List files in `spec/` (and optionally `steering/`).
+2. If `spec/tasks.md` exists, count unchecked `[ ]` vs checked `[x]` and summarize.
+
+## EARS Quick Reference
+
+- **Ubiquitous:** `<system> shall <response>`
+- **Event-Driven:** `WHEN <trigger> [precondition] the <system> shall <response>`
+- **Unwanted:** `IF <unwanted condition> THEN the <system> shall <response>`
+- **State-Driven:** `WHILE <system state>, the <system> shall <response>`
+- **Optional:** `WHERE <feature is included>, the <system> shall <response>`
+
+Use IDs like `[REQ-001]`; add a **Properties (Invariants)** section for universal correctness statements.
+
+## Design Checklist
+
+- Edit ruthlessly (remove over-engineering).
+- Check for circular dependencies; fix via interface extraction, layering, or events.
+- Ensure alignment with steering documents.
+
+## Task Rules
+
+- Two-level hierarchy maximum (Task > Subtask).
+- Sequential order (each task builds on previous).
+- Traceability: each task or subtask links back to requirement IDs (e.g. *Traceability:* Implements `REQ-001`).
+
+## Additional Resources
+
+- For full framework detail (workflow, refinement, iteration triggers), see [reference.md](reference.md).

--- a/_skills/engineering/sdd/index.md
+++ b/_skills/engineering/sdd/index.md
@@ -1,0 +1,106 @@
+---
+name: sdd
+description: >
+  Implements the Spec-Driven Development lifecycle (Intent, Requirements, Design, Tasks, Build)
+  for structured feature development. Use when the user wants to scaffold a new feature spec,
+  generate EARS requirements, create a technical design, break work into tasks, or check spec status.
+  Trigger on keywords: sdd, spec-driven, ears requirements, feature spec.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+tags:
+  - spec-driven-development
+  - requirements
+  - design
+  - documentation
+---
+
+# Spec-Driven Development (SDD)
+
+## Core Philosophy
+
+1. **Clarity before Code:** Never generate code until requirements and design are approved.
+2. **Iterative Refinement:** Loop through Req → Design → Tasks until solid.
+3. **Code via Docs:** The truth is in the markdown files, not the chat.
+
+## Commands
+
+Execute in the **project root** (where `spec/` and `steering/` live).
+
+### `init`
+
+Scaffold the SDD folder structure and template files.
+
+1. If `spec/` already exists, skip or ask before overwriting.
+2. Create `spec/` and `steering/`.
+3. Create `spec/intent.md` (blank or minimal placeholder).
+4. Copy templates from this skill’s `templates/` directory (in the same folder as `SKILL.md`, or from your install path under `~/.cursor/skills/sdd/` after copying the skill there) into the project:
+   - `templates/spec/requirements.md` → `spec/requirements.md`
+   - `templates/spec/design.md` → `spec/design.md`
+   - `templates/spec/tasks.md` → `spec/tasks.md`
+   - `templates/steering/coding-standards.md` → `steering/coding-standards.md`
+
+### `reqs`
+
+Generate EARS requirements from intent.
+
+1. Read `spec/intent.md` and `steering/*.md`.
+2. Convert the intent into EARS requirements (see EARS Quick Reference below). Add a Properties (invariants) section.
+3. Write to `spec/requirements.md`.
+4. Ask for user approval before proceeding.
+
+### `design`
+
+Generate technical design from requirements.
+
+1. Read `spec/requirements.md` and `steering/*.md`.
+2. Create a technical design: architecture, data models, component interfaces, error handling, security. Apply the Design Checklist below.
+3. Write to `spec/design.md`.
+4. Ask for user approval before proceeding.
+
+### `tasks`
+
+Generate implementation tasks from design.
+
+1. Read `spec/design.md` and `spec/requirements.md`.
+2. Create a sequential task list: max two levels (Task > Subtask). Link each task to requirement IDs (e.g. `REQ-001`). Follow Task Rules below.
+3. Write to `spec/tasks.md`.
+4. Ask for user approval before proceeding.
+
+### `status`
+
+Report current state of the spec.
+
+1. List files in `spec/` (and optionally `steering/`).
+2. If `spec/tasks.md` exists, count unchecked `[ ]` vs checked `[x]` and summarize.
+
+## EARS Quick Reference
+
+- **Ubiquitous:** `<system> shall <response>`
+- **Event-Driven:** `WHEN <trigger> [precondition] the <system> shall <response>`
+- **Unwanted:** `IF <unwanted condition> THEN the <system> shall <response>`
+- **State-Driven:** `WHILE <system state>, the <system> shall <response>`
+- **Optional:** `WHERE <feature is included>, the <system> shall <response>`
+
+Use IDs like `[REQ-001]`; add a **Properties (Invariants)** section for universal correctness statements.
+
+## Design Checklist
+
+- Edit ruthlessly (remove over-engineering).
+- Check for circular dependencies; fix via interface extraction, layering, or events.
+- Ensure alignment with steering documents.
+
+## Task Rules
+
+- Two-level hierarchy maximum (Task > Subtask).
+- Sequential order (each task builds on previous).
+- Traceability: each task or subtask links back to requirement IDs (e.g. *Traceability:* Implements `REQ-001`).
+
+## Additional Resources
+
+- For full framework detail (workflow, refinement, iteration triggers), see [reference.md](reference.md).

--- a/_skills/engineering/sdd/reference.md
+++ b/_skills/engineering/sdd/reference.md
@@ -1,0 +1,91 @@
+# Spec-Driven Development (SDD) Framework Extraction
+
+## Core Philosophy (Image 5, 13)
+- **Clarity before Code:** Invest time to understand *what* to build.
+- **Iterative Refinement:** Capture the evolution of the idea.
+- **Code via Docs:** Move from ephemeral chat to persistent, shareable documents.
+- **Goal:** AI under control. Specification driven lifecycle.
+
+## The Workflow (Image 3, 6, 15, 17)
+1.  **The Vibe (Exploration):** Use "vibe coding" (casual chat) to explore and experiment. Get a handle on what you really want.
+2.  **Intent:** "Spec-driven development" starts here. The output of "The Vibe" becomes the input for the Spec.
+3.  **Opinionated Workflow (The "Spec" Loop):**
+    *   **Requirements:** Generate concrete, measurable requirements (EARS syntax).
+    *   **Design:** Create initial design (Architecture, Data Models, Interfaces).
+    *   **Tasks:** Define sequential, testable tasks.
+    *   *Loop:* Iterate, Refine, Approval at each step.
+4.  **Implementation:**
+    *   Generate code from tasks.
+    *   Test/QA.
+    *   Fix Issues (Loop back if needed).
+5.  **Deployment & Maintenance.**
+
+## Detailed Components
+
+### 1. Context & Steering (Image 1, 7)
+- **Concept:** "Steering Documents" align the AI with the Intent.
+- **Smart Context:** Automatic, Pattern Match, or Manual.
+- **Strategies:**
+    - Start small (core needs only).
+    - Use descriptive names (e.g., `api-rest-conventions.md`).
+    - **Examples are key:** Code snippets, input/outputs, style guides.
+    - **Security First:** No secrets in steering docs.
+
+### 2. Requirements (Image 9, 10, 18, 22)
+- **Format:** **EARS** (Easy Application Requirements Syntax). Optimized for LLMs.
+    - *Ubiquitous:* `<system> shall <response>`
+    - *Event-Driven:* `WHEN <trigger> then <system> shall <response>`
+    - *Unwanted:* `IF <unwanted> THEN <system> shall <response>`
+    - *State-Driven:* `WHILE <state>, <system> shall <response>`
+    - *Optional:* `WHERE <feature>, <system> shall <response>`
+- **Refinement:**
+    - **Review:** Get stakeholder feedback.
+    - **Identify Gaps:** Missing scenarios?
+    - **Clarify Ambiguities:** Resolve vague/conflicting reqs.
+    - **Edge Cases:** Add missing details and error handling.
+- **Properties:** Define invariants/correctness properties. "Universal statements about how system should behave" (Image 18).
+
+### 3. Design (Image 8, 20, 21)
+- **Content:** Architecture, Components, Interfaces, Data Models, Error Handling, Test Strategy, Security, Perf.
+- **Refinement:**
+    - **Include Examples:** Help steer the AI.
+    - **Edit Ruthlessly:** LLMs over-engineer. Cut the fluff.
+    - **Check Missing Items:** Components or details dropped?
+    - **Alignment:** Does it match steering?
+    - **Circular Dependencies:** Watch out for them. Fix via Interface Extraction, Layering, or Decoupling (Events).
+
+### 4. Tasks (Image 2, 4, 14, 41)
+- **Structure:**
+    - **Two-Level Max:** Top-level tasks + sub-tasks. No deep nesting.
+    - **Logical Grouping:** Meaningful categories.
+    - **Sequential:** Build on previous work.
+    - **Traceability:** Link tasks back to Requirement IDs (e.g., `Requirements: 1.1, 5.4`).
+- **Dependency Management:**
+    - **Technical:** Components that must exist first (e.g., DB models before endpoints).
+    - **Logical:** Features that conceptually build on others (e.g., User Reg before Profile Edit).
+    - **Data:** Tasks requiring specific state (e.g., Transaction history requires Transaction data).
+- **Prioritization:**
+    - **Core First:** Essential functionality.
+    - **Risk First:** Uncertain/complex tasks early.
+    - **Value First:** High value, testable quickly.
+
+## Comparison (Image 19)
+- **vs TDD:** SDD is higher level (business reqs + system design).
+- **vs Waterfall:** SDD is iterative within phases. Living docs. Optimized for feature-level dev.
+- **vs BDD:** SDD uses explicit requirements gathering (EARS) + AI-focused structure.
+
+## Iteration & Maintenance (Image 22)
+**Triggers for updating your specification:**
+1.  **Clarification:** Minor updates for precision (no functional change).
+2.  **Changes:** New requirements or modifications to existing ones.
+3.  **Discoveries:** Implementation details (tech constraints) found during coding that force design changes.
+4.  **Technical Constraints:** Library limitations, performance issues, security concerns found during generation.
+5.  **Integration Challenges:** Data format mismatches, auth issues, interface updates.
+6.  **Feedback:** User feedback, accessibility, mobile support issues.
+
+## Artifacts to Generate
+- `spec/intent.md`
+- `spec/requirements.md` (EARS)
+- `spec/design.md`
+- `spec/tasks.md`
+- `steering/*.md` (Context)

--- a/_skills/engineering/sdd/templates/spec/design.md
+++ b/_skills/engineering/sdd/templates/spec/design.md
@@ -1,0 +1,23 @@
+# Design Specification
+
+> **Guidance:**
+> - Edit ruthlessly (remove over-engineering).
+> - Check for circular dependencies.
+> - Ensure alignment with Steering docs.
+
+## Architecture
+*(Diagrams or text description of components and data flow)*
+
+## Data Models
+```typescript
+// Example interfaces or schemas
+```
+
+## Component Interfaces
+*(Key method signatures and contracts)*
+
+## Error Handling
+*(Strategy for failures)*
+
+## Security Considerations
+*(Auth, data protection, no secrets in code)*

--- a/_skills/engineering/sdd/templates/spec/requirements.md
+++ b/_skills/engineering/sdd/templates/spec/requirements.md
@@ -1,0 +1,19 @@
+# Requirements
+
+> **Format:** EARS (Easy Application Requirements Syntax)
+> **Syntax:**
+> - Ubiquitous: `<system> shall <response>`
+> - Event-Driven: `WHEN <trigger> <optional precondition> the <system> shall <response>`
+> - Unwanted: `IF <unwanted condition> THEN the <system> shall <response>`
+> - State-Driven: `WHILE <system state>, the <system> shall <response>`
+> - Optional: `WHERE <feature is included>, the <system> shall <response>`
+
+## Core Requirements
+
+1. **[REQ-001]** ...
+2. **[REQ-002]** ...
+
+## Properties (Invariants)
+*Universal statements that must always hold true.*
+
+1. **[PROP-001]** ...

--- a/_skills/engineering/sdd/templates/spec/tasks.md
+++ b/_skills/engineering/sdd/templates/spec/tasks.md
@@ -1,0 +1,16 @@
+# Implementation Plan
+
+> **Rules:**
+> - Two-level hierarchy maximum (Task > Subtask).
+> - Sequential order (builds on previous).
+> - Traceability: Link back to Req IDs.
+
+## Phase 1: Core Foundation
+
+- [ ] **Task 1: [Task Name]**
+    - [ ] 1.1: Implementation step...
+    - [ ] 1.2: Verification step...
+    - *Traceability:* Implements `REQ-001`
+
+- [ ] **Task 2: [Task Name]**
+    - ...

--- a/_skills/engineering/sdd/templates/steering/coding-standards.md
+++ b/_skills/engineering/sdd/templates/steering/coding-standards.md
@@ -1,0 +1,14 @@
+# Coding Standards
+
+> **Purpose:** Steer the AI on style, patterns, and forbidden practices.
+
+## General
+- Language: [e.g. TypeScript / Python]
+- Framework: [e.g. Node.js / React]
+
+## Patterns
+- [Pattern 1]
+- [Pattern 2]
+
+## Examples
+*(Provide good/bad examples here)*

--- a/_skills/engineering/techdebt/SKILL.md
+++ b/_skills/engineering/techdebt/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: techdebt
+description: Find and fix technical debt including duplicated code, dead code, outdated patterns, and code smells. Run at the end of sessions to clean up.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+disable-model-invocation: true
+tags:
+  - refactoring
+  - code-quality
+  - maintenance
+---
+
+# Technical Debt Finder
+
+Identify and fix technical debt in the codebase.
+
+## What to Look For
+
+### Code Duplication
+- Functions with similar logic that could be consolidated
+- Copy-pasted code blocks
+- Repeated patterns that should be abstracted
+
+### Dead Code
+- Unused imports
+- Unused functions or classes
+- Commented-out code blocks
+- Unreachable code paths
+
+### Outdated Patterns
+- Deprecated API usage
+- Old-style string formatting (% or .format) vs f-strings
+- Type hints using `typing.List` instead of `list`
+- Missing type hints on public functions
+
+### Code Smells
+- Functions longer than 50 lines
+- Too many parameters (more than 5)
+- Deep nesting (more than 3 levels)
+- Magic numbers without constants
+- Overly complex conditionals
+
+### Missing Best Practices
+- Missing docstrings on public functions
+- Missing error handling
+- Hardcoded values that should be config
+- Missing tests for critical paths
+
+## Workflow
+
+1. **Scan the Codebase**
+   - Look for patterns matching the issues above
+   - Prioritize by impact and ease of fix
+
+2. **Report Findings**
+   - List issues by category
+   - Include file paths and line numbers
+   - Estimate severity (high/medium/low)
+
+3. **Fix Issues**
+   - Start with high-severity, easy fixes
+   - Create atomic commits for each fix
+   - Run tests after each change
+
+4. **Verify**
+   - Run linter: `ruff check .`
+   - Run tests: `pytest`
+   - Ensure no new issues introduced
+
+## Arguments
+
+Optionally specify a directory or file to focus on.
+
+Usage:
+- `/techdebt` - Scan entire project
+- `/techdebt src/` - Scan specific directory
+- `/techdebt src/utils.py` - Scan specific file
+
+## Output
+
+Provide a summary of:
+- Issues found (by category)
+- Issues fixed
+- Remaining items for future sessions

--- a/_skills/engineering/techdebt/index.md
+++ b/_skills/engineering/techdebt/index.md
@@ -1,0 +1,90 @@
+---
+name: techdebt
+description: Find and fix technical debt including duplicated code, dead code, outdated patterns, and code smells. Run at the end of sessions to clean up.
+workflow_stage: engineering
+compatibility:
+  - claude-code
+  - cursor
+  - codex
+  - gemini-cli
+author: Awesome Econ AI Community
+version: 1.0.0
+disable-model-invocation: true
+tags:
+  - refactoring
+  - code-quality
+  - maintenance
+---
+
+# Technical Debt Finder
+
+Identify and fix technical debt in the codebase.
+
+## What to Look For
+
+### Code Duplication
+- Functions with similar logic that could be consolidated
+- Copy-pasted code blocks
+- Repeated patterns that should be abstracted
+
+### Dead Code
+- Unused imports
+- Unused functions or classes
+- Commented-out code blocks
+- Unreachable code paths
+
+### Outdated Patterns
+- Deprecated API usage
+- Old-style string formatting (% or .format) vs f-strings
+- Type hints using `typing.List` instead of `list`
+- Missing type hints on public functions
+
+### Code Smells
+- Functions longer than 50 lines
+- Too many parameters (more than 5)
+- Deep nesting (more than 3 levels)
+- Magic numbers without constants
+- Overly complex conditionals
+
+### Missing Best Practices
+- Missing docstrings on public functions
+- Missing error handling
+- Hardcoded values that should be config
+- Missing tests for critical paths
+
+## Workflow
+
+1. **Scan the Codebase**
+   - Look for patterns matching the issues above
+   - Prioritize by impact and ease of fix
+
+2. **Report Findings**
+   - List issues by category
+   - Include file paths and line numbers
+   - Estimate severity (high/medium/low)
+
+3. **Fix Issues**
+   - Start with high-severity, easy fixes
+   - Create atomic commits for each fix
+   - Run tests after each change
+
+4. **Verify**
+   - Run linter: `ruff check .`
+   - Run tests: `pytest`
+   - Ensure no new issues introduced
+
+## Arguments
+
+Optionally specify a directory or file to focus on.
+
+Usage:
+- `/techdebt` - Scan entire project
+- `/techdebt src/` - Scan specific directory
+- `/techdebt src/utils.py` - Scan specific file
+
+## Output
+
+Provide a summary of:
+- Issues found (by category)
+- Issues fixed
+- Remaining items for future sessions

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -8,6 +8,16 @@
 const GITHUB_REPO = 'meleantonio/awesome-econ-ai-stuff';
 const GITHUB_BRANCH = 'main'; // or 'master', adjust as needed
 
+/** SDD skill includes templates and reference — shared between zip-all and single-page bundle download */
+const SDD_BUNDLE_BASE = '_skills/engineering/sdd';
+const SDD_BUNDLE_FILES = [
+    'reference.md',
+    'templates/spec/requirements.md',
+    'templates/spec/design.md',
+    'templates/spec/tasks.md',
+    'templates/steering/coding-standards.md'
+];
+
 /**
  * List of all skills with their paths
  * This should match the actual structure in the skills directory
@@ -19,12 +29,17 @@ const SKILLS_LIST = [
     { path: '_skills/data/stata-data-cleaning/SKILL.md', name: 'stata-data-cleaning' },
     { path: '_skills/data/api-data-fetcher/SKILL.md', name: 'api-data-fetcher' },
     { path: '_skills/theory/latex-econ-model/SKILL.md', name: 'latex-econ-model' },
+    { path: '_skills/theory/general-equilibrium-model-builder/SKILL.md', name: 'general-equilibrium-model-builder' },
     { path: '_skills/writing/academic-paper-writer/SKILL.md', name: 'academic-paper-writer' },
     { path: '_skills/writing/latex-tables/SKILL.md', name: 'latex-tables' },
     { path: '_skills/communication/beamer-presentation/SKILL.md', name: 'beamer-presentation' },
     { path: '_skills/communication/econ-visualization/SKILL.md', name: 'econ-visualization' },
     { path: '_skills/ideation/research-ideation/SKILL.md', name: 'research-ideation' },
-    { path: '_skills/literature/lit-review-assistant/SKILL.md', name: 'lit-review-assistant' }
+    { path: '_skills/literature/lit-review-assistant/SKILL.md', name: 'lit-review-assistant' },
+    { path: `${SDD_BUNDLE_BASE}/SKILL.md`, name: 'sdd', bundleBase: SDD_BUNDLE_BASE, bundleFiles: SDD_BUNDLE_FILES },
+    { path: '_skills/engineering/techdebt/SKILL.md', name: 'techdebt' },
+    { path: '_skills/engineering/commit-push-pr/SKILL.md', name: 'commit-push-pr' },
+    { path: '_skills/engineering/code-simplifier/SKILL.md', name: 'code-simplifier' }
 ];
 
 /**
@@ -104,15 +119,23 @@ async function downloadAllSkills() {
         const fetchPromises = SKILLS_LIST.map(async (skill) => {
             try {
                 const content = await fetchFileContent(skill.path);
-                
+
                 // Preserve directory structure in zip
                 const pathParts = skill.path.split('/');
                 const category = pathParts[1]; // e.g., 'analysis'
                 const skillName = pathParts[2]; // e.g., 'r-econometrics'
-                
+
                 const categoryFolder = skillsFolder.folder(category);
                 const skillFolder = categoryFolder.folder(skillName);
                 skillFolder.file('SKILL.md', content);
+
+                if (skill.bundleBase && skill.bundleFiles && skill.bundleFiles.length) {
+                    for (const rel of skill.bundleFiles) {
+                        const fullPath = `${skill.bundleBase}/${rel}`;
+                        const extra = await fetchFileContent(fullPath);
+                        skillFolder.file(rel, extra);
+                    }
+                }
             } catch (error) {
                 console.error(`Error fetching ${skill.path}:`, error);
                 // Continue with other files even if one fails
@@ -206,6 +229,58 @@ async function downloadSkillFile() {
     }
 }
 
+/**
+ * Download full SDD skill folder (SKILL.md + templates + reference) as a zip
+ */
+async function downloadSddSkillBundle() {
+    const button = document.getElementById('download-skill-bundle-btn');
+    if (button) {
+        button.disabled = true;
+        button.textContent = 'Downloading...';
+    }
+
+    try {
+        const JSZip = window.JSZip;
+        if (!JSZip) {
+            throw new Error('JSZip library not loaded');
+        }
+
+        const zip = new JSZip();
+        const skillFolder = zip.folder('sdd');
+
+        const skillMd = await fetchFileContent(`${SDD_BUNDLE_BASE}/SKILL.md`);
+        skillFolder.file('SKILL.md', skillMd);
+
+        for (const rel of SDD_BUNDLE_FILES) {
+            const fullPath = `${SDD_BUNDLE_BASE}/${rel}`;
+            const extra = await fetchFileContent(fullPath);
+            skillFolder.file(rel, extra);
+        }
+
+        const blob = await zip.generateAsync({ type: 'blob' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'sdd-skill-bundle.zip';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        if (button) {
+            button.disabled = false;
+            button.textContent = '📦 Download full skill (zip)';
+        }
+    } catch (error) {
+        console.error('Error downloading SDD bundle:', error);
+        alert('Failed to download skill bundle. Please try again.');
+        if (button) {
+            button.disabled = false;
+            button.textContent = '📦 Download full skill (zip)';
+        }
+    }
+}
+
 // Initialize download buttons when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize download all button
@@ -218,5 +293,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const downloadSkillBtn = document.getElementById('download-skill-btn');
     if (downloadSkillBtn) {
         downloadSkillBtn.addEventListener('click', downloadSkillFile);
+    }
+
+    const downloadSddBundleBtn = document.getElementById('download-skill-bundle-btn');
+    if (downloadSddBundleBtn) {
+        downloadSddBundleBtn.addEventListener('click', downloadSddSkillBundle);
     }
 });

--- a/cursor_chat_recording.md
+++ b/cursor_chat_recording.md
@@ -136,3 +136,14 @@ Assistant actions:
 - Removed the three bullets from README and clarified the earlier #24 session note in this file.
 - Opened PR: https://github.com/meleantonio/awesome-econ-ai-stuff/pull/27
 
+---
+
+## 2026-03-22 (Copy ~/.cursor/skills into repo + engineering category)
+
+User request:
+- Copy skills from `~/.cursor/skills/` into `_skills/engineering/` (sdd, techdebt, commit-push-pr, code-simplifier), integrate the Jekyll site: new filter tab, `download.js`, deploy workflow `_skills` path, README/CONTRIBUTING/submit form, SDD bundle zip for templates + reference.
+
+Assistant actions:
+- Added `_skills/engineering/` with normalized front matter (`workflow_stage: engineering`), synced `index.md` from `SKILL.md`.
+- Updated `index.html` (8 categories, Engineering filter + Liquid case), `assets/js/download.js` (SDD bundle constants, `general-equilibrium-model-builder` in zip-all), `_layouts/skill.html` (SDD full zip button), `.github/workflows/deploy.yml` (`_skills` root), `README.md`, `CONTRIBUTING.md`, `pages/submit.html`.
+

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
                     <span class="stat-label">Skills</span>
                 </div>
                 <div class="stat">
-                    <span class="stat-value">7</span>
+                    <span class="stat-value">8</span>
                     <span class="stat-label">Categories</span>
                 </div>
                 <div class="stat">
@@ -111,6 +111,7 @@
                 <button class="filter-tab" data-filter="analysis">🔬 Analysis</button>
                 <button class="filter-tab" data-filter="writing">📝 Writing</button>
                 <button class="filter-tab" data-filter="communication">🎯 Communication</button>
+                <button class="filter-tab" data-filter="engineering">⚙️ Engineering</button>
             </div>
 
             <!-- Skills Grid - Dynamically generated from skill collection -->
@@ -143,6 +144,9 @@
                             {% when 'communication' %}
                                 {% assign skill_icon = "🎯" %}
                                 {% assign skill_label = "Communication" %}
+                            {% when 'engineering' %}
+                                {% assign skill_icon = "⚙️" %}
+                                {% assign skill_label = "Engineering" %}
                         {% endcase %}
 
                         <article class="skill-card" data-category="{{ category }}">

--- a/pages/submit.html
+++ b/pages/submit.html
@@ -74,6 +74,7 @@
                                     <option value="analysis">🔬 Econometric Analysis</option>
                                     <option value="writing">📝 Academic Writing</option>
                                     <option value="communication">🎯 Communication</option>
+                                    <option value="engineering">⚙️ Engineering</option>
                                 </select>
                             </div>
 


### PR DESCRIPTION
## Summary

This pull request adds four skills copied from the Cursor skills workflow into `_skills/engineering/` and wires them into the Jekyll site.

## Changes

- **New skills:** `sdd` (with templates + reference), `techdebt`, `commit-push-pr`, `code-simplifier` — each with `SKILL.md` + `index.md` and `workflow_stage: engineering`.
- **Homepage:** New "Engineering" filter tab, Liquid case for icons/labels, category count 8.
- **Downloads:** `SKILLS_LIST` extended; SDD multi-file bundle in "download all" zip; optional full SDD zip on the SDD skill page; `general-equilibrium-model-builder` included in zip-all.
- **CI:** Deploy workflow generates `index.md` from `_skills/` (fixes wrong `skills/` path).
- **Docs:** README catalog, CONTRIBUTING (`_skills/` + engineering stage), submit form option.

## Notes

Original skills remain in `~/.cursor/skills/`; this repo holds copies for the catalog and GitHub Pages.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Engineering skill category with 4 new skills: Spec-Driven Development, Technical Debt Finder, Code Simplifier, and Commit-Push-PR workflow
  * Enhanced skill download functionality with bundled downloads
  * Skills catalog now displays 8 categories with new Engineering filter

* **Documentation**
  * Updated contribution and submission guides to include the new engineering category

<!-- end of auto-generated comment: release notes by coderabbit.ai -->